### PR TITLE
slack notifications from jovian [ch220]

### DIFF
--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -5,7 +5,7 @@ from time import sleep
 from jovian.utils.anaconda import upload_conda_env, CondaError
 from jovian.utils.pip import upload_pip_env
 from jovian.utils.api import (create_gist_simple, upload_file, get_gist_access,
-                              post_block, commit_records, notify_on_slack)
+                              post_block, commit_records, post_slack_message)
 from jovian.utils.logger import log
 from jovian.utils.constants import WEBAPP_URL, FILENAME_MSG, RC_FILENAME
 from jovian.utils.jupyter import set_notebook_name, in_notebook, save_notebook, get_notebook_name
@@ -215,10 +215,9 @@ def notify(data, verbose=True):
     """Sends the data to Slack connected to Jovian account
 
     Arguments:
-        :param data: A dict or string of dicts to be pushed to Slack
-        :param verbose: Want to see logs in stdout, default=True
+        data: A dict or string to be pushed to Slack
     """
-    res = notify_on_slack(data=data)
+    res = post_slack_message(data=data)
     if verbose:
         if not res.get('errors'):
             log('message_sent:' + str(res.get('data').get('messageSent')))

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -5,7 +5,7 @@ from time import sleep
 from jovian.utils.anaconda import upload_conda_env, CondaError
 from jovian.utils.pip import upload_pip_env
 from jovian.utils.api import (create_gist_simple, upload_file, get_gist_access,
-                              post_block, commit_records)
+                              post_block, commit_records, notify_on_slack)
 from jovian.utils.logger import log
 from jovian.utils.constants import WEBAPP_URL, FILENAME_MSG, RC_FILENAME
 from jovian.utils.jupyter import set_notebook_name, in_notebook, save_notebook, get_notebook_name
@@ -194,7 +194,7 @@ def log_hyperparams(data, verbose=True):
     global _data_blocks
     res = post_block(data, 'hyperparams')
     _data_blocks.append(res['tracking']['trackingSlug'])
-    if(verbose):
+    if verbose:
         log('Hyperparameters logged.')
 
 
@@ -207,5 +207,20 @@ def log_metrics(data, verbose=True):
     global _data_blocks
     res = post_block(data, 'metrics')
     _data_blocks.append(res['tracking']['trackingSlug'])
-    if(verbose):
+    if verbose:
         log('Metrics logged.')
+
+
+def notify(data, verbose=True):
+    """Sends the data to Slack connected to Jovian account
+
+    Arguments:
+        :param data: A dict or string of dicts to be pushed to Slack
+        :param verbose: Want to see logs in stdout, default=True
+    """
+    res = notify_on_slack(data=data)
+    if verbose:
+        if res.get('message_sent'):
+            log('message_sent:', str(res.get('message_sent')))
+        else:
+            log('error: ', str(res.get('error')))

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -221,6 +221,6 @@ def notify(data, verbose=True):
     res = notify_on_slack(data=data)
     if verbose:
         if res.get('message_sent'):
-            log('message_sent:', str(res.get('message_sent')))
+            log('message_sent:' + str(res.get('message_sent')))
         else:
-            log('error: ', str(res.get('error')))
+            log(str(res.get('error')), error=True)

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -223,4 +223,4 @@ def notify(data, verbose=True):
         if res.get('message_sent'):
             log('message_sent:' + str(res.get('message_sent')))
         else:
-            log(str(res.get('error')), error=True)
+            log(str(res.get('message')), error=True)

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -220,7 +220,7 @@ def notify(data, verbose=True):
     """
     res = notify_on_slack(data=data)
     if verbose:
-        if res.get('message_sent'):
-            log('message_sent:' + str(res.get('message_sent')))
+        if not res.get('errors'):
+            log('message_sent:' + str(res.get('data').get('messageSent')))
         else:
-            log(str(res.get('message')), error=True)
+            log(str(res.get('errors')[0].get('message')), error=True)

--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -3,8 +3,8 @@ import os
 
 from jovian.utils.clone import clone, pull
 from jovian.utils.install import install, activate
-from jovian._version import __version__
 from jovian.utils.slack import add_slack
+from jovian._version import __version__
 
 
 def exec_clone(slug, version):

--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -1,10 +1,11 @@
 import argparse
-import webbrowser
+# import webbrowser
 import os
 
 from jovian.utils.clone import clone, pull
 from jovian.utils.install import install, activate
 from jovian._version import __version__
+from jovian.utils.api import add_slack
 
 
 def exec_clone(slug, version):
@@ -55,6 +56,8 @@ def main():
         nb_ext()
     elif command == 'disable_ext':
         nb_ext(enable=False)
+    elif command == 'add-slack':
+        add_slack()
 
 
 if __name__ == '__main__':

--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -1,11 +1,10 @@
 import argparse
-# import webbrowser
 import os
 
 from jovian.utils.clone import clone, pull
 from jovian.utils.install import install, activate
 from jovian._version import __version__
-from jovian.utils.api import add_slack
+from jovian.utils.slack import add_slack
 
 
 def exec_clone(slug, version):
@@ -15,7 +14,6 @@ def exec_clone(slug, version):
 def exec_init():
     from jovian.utils.api import get_api_key
     from jovian.utils.credentials import get_guest_key
-    # webbrowser.open('https://jvn.io/')
     get_guest_key()
     get_api_key()
     print('Initialization finished')

--- a/jovian/utils/api.py
+++ b/jovian/utils/api.py
@@ -157,11 +157,10 @@ def commit_records(gist_slug, tracking_slugs, version=None):
 
 
 def notify_on_slack(data):
-    """Push data to Slack, if slack integrated with jovian account"""
+    """Push data to Slack, if slack is integrated with jovian account"""
     url = _u('/slack/notify')
     res = post(url, json=data, headers=_h())
     if res.status_code == 200:
-        response = res.json()
-        return response.get('data') if not response.get('errors') else response.get('errors')
+        return res.json()
     else:
         raise ApiError('Slack trigger failed: ' + _pretty(res))

--- a/jovian/utils/api.py
+++ b/jovian/utils/api.py
@@ -164,3 +164,20 @@ def notify_on_slack(data):
         return res.json()
     else:
         raise ApiError('Slack trigger failed: ' + _pretty(res))
+
+
+def add_slack():
+    """prints instructions for connecting Slack, if Slack connection is not already present.
+    if Slack is already connected, prints details about the workspace and the channel"""
+    url = _u('/slack/integration_details')
+    res = get(url, headers=_h())
+    if res.status_code == 200:
+        res = res.json()
+        if not res.get('errors'):
+            slack_account = res.get('data').get('slackAccount')
+            log('Slack already connected. \nWorkspace: {}\nConnected Channel: {}'
+                .format(slack_account.get('workspace'), slack_account.get('channel')))
+        else:
+            log(str(res.get('errors')[0].get('message')))
+    else:
+        raise ApiError('Slack trigger failed: ' + _pretty(res))

--- a/jovian/utils/api.py
+++ b/jovian/utils/api.py
@@ -156,7 +156,7 @@ def commit_records(gist_slug, tracking_slugs, version=None):
         raise ApiError('Data logging failed: ' + _pretty(res))
 
 
-def notify_on_slack(data):
+def post_slack_message(data):
     """Push data to Slack, if slack is integrated with jovian account"""
     url = _u('/slack/notify')
     res = post(url, json=data, headers=_h())
@@ -165,19 +165,3 @@ def notify_on_slack(data):
     else:
         raise ApiError('Slack trigger failed: ' + _pretty(res))
 
-
-def add_slack():
-    """prints instructions for connecting Slack, if Slack connection is not already present.
-    if Slack is already connected, prints details about the workspace and the channel"""
-    url = _u('/slack/integration_details')
-    res = get(url, headers=_h())
-    if res.status_code == 200:
-        res = res.json()
-        if not res.get('errors'):
-            slack_account = res.get('data').get('slackAccount')
-            log('Slack already connected. \nWorkspace: {}\nConnected Channel: {}'
-                .format(slack_account.get('workspace'), slack_account.get('channel')))
-        else:
-            log(str(res.get('errors')[0].get('message')))
-    else:
-        raise ApiError('Slack trigger failed: ' + _pretty(res))

--- a/jovian/utils/api.py
+++ b/jovian/utils/api.py
@@ -154,3 +154,13 @@ def commit_records(gist_slug, tracking_slugs, version=None):
         return res.json()['data']
     else:
         raise ApiError('Data logging failed: ' + _pretty(res))
+
+
+def notify_on_slack(data):
+    """Push data to Slack, if slack integrated with jovian account"""
+    url = _u('/slack/notify')
+    res = post(url, json=data, headers=_h())
+    if res.status_code == 200:
+        return res.json()['data']
+    else:
+        raise ApiError('Slack trigger failed: ' + _pretty(res))

--- a/jovian/utils/api.py
+++ b/jovian/utils/api.py
@@ -161,6 +161,7 @@ def notify_on_slack(data):
     url = _u('/slack/notify')
     res = post(url, json=data, headers=_h())
     if res.status_code == 200:
-        return res.json()['data']
+        response = res.json()
+        return response.get('data') if not response.get('errors') else response.get('errors')
     else:
         raise ApiError('Slack trigger failed: ' + _pretty(res))

--- a/jovian/utils/slack.py
+++ b/jovian/utils/slack.py
@@ -3,10 +3,13 @@ from requests import get
 from jovian.utils.constants import API_URL
 from jovian.utils.credentials import get_guest_key, read_api_key_opt
 from jovian.utils.logger import log
+from jovian._version import __version__
+
 
 class ApiError(Exception):
     """Error class for web API related Exceptions"""
     pass
+
 
 def _u(path):
     """Make a URL from the path"""
@@ -33,13 +36,13 @@ def _pretty(res):
     return '(HTTP ' + str(res.status_code) + ') ' + _msg(res)
 
 
-def _h(fresh):
+def _h():
     """Create a header to provide library metadata"""
     api_key, _ = read_api_key_opt()
 
     headers = {"x-jovian-source": "library",
                "x-jovian-library-version": __version__,
-               "x-jovian-command": "clone" if fresh else "pull",
+               "x-jovian-command": "add-slack",
                "x-jovian-guest": get_guest_key()}
 
     if api_key is not None:

--- a/jovian/utils/slack.py
+++ b/jovian/utils/slack.py
@@ -1,0 +1,72 @@
+import os
+from requests import get
+from jovian.utils.constants import API_URL
+from jovian.utils.credentials import get_guest_key, read_api_key_opt
+from jovian.utils.logger import log
+
+class ApiError(Exception):
+    """Error class for web API related Exceptions"""
+    pass
+
+def _u(path):
+    """Make a URL from the path"""
+    return API_URL + path
+
+
+def _msg(res):
+    try:
+        data = res.json()
+        if 'errors' in data and len(data['errors'] > 0):
+            return data['errors'][0]['message']
+        if 'message' in data:
+            return data['message']
+        if 'msg' in data:
+            return data['msg']
+    except:
+        if res.text:
+            return res.text
+        return 'Something went wrong'
+
+
+def _pretty(res):
+    """Make a human readable output from an HTML response"""
+    return '(HTTP ' + str(res.status_code) + ') ' + _msg(res)
+
+
+def _h(fresh):
+    """Create a header to provide library metadata"""
+    api_key, _ = read_api_key_opt()
+
+    headers = {"x-jovian-source": "library",
+               "x-jovian-library-version": __version__,
+               "x-jovian-command": "clone" if fresh else "pull",
+               "x-jovian-guest": get_guest_key()}
+
+    if api_key is not None:
+        headers["Authorization"] = "Bearer " + api_key
+
+    return headers
+
+
+def _v(version):
+    """Create version query parameter string"""
+    if version is not None:
+        return "?gist_version=" + str(version)
+    return ""
+
+
+def add_slack():
+    """prints instructions for connecting Slack, if Slack connection is not already present.
+    if Slack is already connected, prints details about the workspace and the channel"""
+    url = _u('/slack/integration_details')
+    res = get(url, headers=_h())
+    if res.status_code == 200:
+        res = res.json()
+        if not res.get('errors'):
+            slack_account = res.get('data').get('slackAccount')
+            log('Slack already connected. \nWorkspace: {}\nConnected Channel: {}'
+                .format(slack_account.get('workspace'), slack_account.get('channel')))
+        else:
+            log(str(res.get('errors')[0].get('message')))
+    else:
+        raise ApiError('Slack trigger failed: ' + _pretty(res))


### PR DESCRIPTION
[ch220]

Use `jovian.notify(data)` to push a string or dictionary to Slack.     
Throws error if Slack is not connected to Jovian account.
![image](https://user-images.githubusercontent.com/31766084/63432362-a6627e80-c43e-11e9-9a8f-f95a2c5c5bc9.png)


`jovian add-slack` command: Prints steps to connect Slack to Jovian account, or prints the conneced workspace and channel, in case Slack is already connected.
![image](https://user-images.githubusercontent.com/31766084/63432212-5edbf280-c43e-11e9-83cd-9590454e252f.png)

[ch220]