### PR TITLE
Document CLI commands, Callbacks.

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -12,8 +12,8 @@ ul {
 .wy-side-nav-search > a img.logo {
   /* Side nav bar logo */
   background-color: white;
-  border-radius: 10px;
-  max-width: 80%;
+  border-radius: 5px;
+  max-width: 50%;
 }
 
 .wy-side-nav-search {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -66,6 +66,6 @@ ul {
 .sig-param {
   /*  All the arguments of a function
       By default all the arguments are too close */
-  padding-left: 5px;
+  padding-left: 4px;
   padding-right: 2px;
 }

--- a/docs/callbacks/fastai.md
+++ b/docs/callbacks/fastai.md
@@ -1,1 +1,5 @@
-# Fastai Callback
+## Fastai Callback
+
+```eval_rst
+.. autoclass:: jovian.callbacks.fastai_callback.FastaiCallback
+```

--- a/docs/callbacks/keras.md
+++ b/docs/callbacks/keras.md
@@ -1,1 +1,5 @@
-# Keras Callback
+## Keras Callback
+
+```eval_rst
+.. autoclass:: jovian.callbacks.keras_callback.KerasCallback
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,37 +3,39 @@ import sys
 
 from recommonmark.transform import AutoStructify
 
-sys.path.insert(0, os.path.abspath('../')) # source path to access the module 
+sys.path.insert(0, os.path.abspath('../'))  # source path to access the module
 
 project = 'Jovian'
 copyright = '2019, SwiftAce Inc'
 author = 'Aakash N S, Siddhant Ujjain'
 
-extensions = ['recommonmark', # to use .md along with .rst
-              'sphinx.ext.autodoc', # import doc from docstrings
-              'sphinx.ext.linkcode', # linking the source code on github
-              'sphinxcontrib.napoleon'] # to support Google style docstrings for autdoc
+extensions = ['recommonmark',  # to use .md along with .rst
+              'sphinx.ext.autodoc',  # import doc from docstrings
+              'sphinx.ext.linkcode',  # linking the source code on github
+              'sphinxcontrib.napoleon']  # to support Google style docstrings for autdoc
 
 master_doc = 'index'
 source_suffix = ['.rst', '.md']
 
+autodoc_mock_imports = ["torch", "fastai", "keras"]
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_theme = 'sphinx_rtd_theme'
 
 html_static_path = ['_static']
-html_style = 'css/custom.css' # adding some custom styles on the theme
+html_style = 'css/custom.css'  # adding some custom styles on the theme
 
 html_logo = 'jvn_full_logo.png'
 html_theme_options = {
-    'logo_only' : True # to display only logo on the side nav bar
+    'logo_only': True  # to display only logo on the side nav bar
 }
 
-html_icon = 'jovian_favicon.png' # icon next to title on the browser's tab
+html_icon = 'jovian_favicon.png'  # icon next to title on the browser's tab
+
 
 def setup(app):
     """Enables to embed reStructuredText(rst) in a markdown(.md)
-    
+
     https://recommonmark.readthedocs.io/en/latest/auto_structify.html#embed-restructuredtext
     """
 
@@ -45,9 +47,10 @@ def setup(app):
     }, True)
     app.add_transform(AutoStructify)
 
+
 def linkcode_resolve(domain, info):
     """To provide github source link for the methods
-    
+
     https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
     """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,11 +12,7 @@ author = 'Aakash N S, Siddhant Ujjain'
 extensions = ['recommonmark',  # to use .md along with .rst
               'sphinx.ext.autodoc',  # import doc from docstrings
               'sphinx.ext.linkcode',  # linking the source code on github
-<<<<<<< HEAD
               'sphinxcontrib.napoleon']  # to support Google style docstrings for autodoc
-=======
-              'sphinxcontrib.napoleon']  # to support Google style docstrings for autdoc
->>>>>>> 1c133726540984c65cb37f7146514186bbcb707c
 
 master_doc = 'index'
 source_suffix = ['.rst', '.md']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ html_theme_options = {
     'logo_only': True  # to display only logo on the side nav bar
 }
 
-html_icon = 'jovian_favicon.png'  # icon next to title on the browser's tab
+html_favicon = 'jovian_favicon.png'  # icon next to title on the browser's tab
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ author = 'Aakash N S, Siddhant Ujjain'
 extensions = ['recommonmark',  # to use .md along with .rst
               'sphinx.ext.autodoc',  # import doc from docstrings
               'sphinx.ext.linkcode',  # linking the source code on github
-              'sphinxcontrib.napoleon']  # to support Google style docstrings for autdoc
+              'sphinxcontrib.napoleon']  # to support Google style docstrings for autodoc
 
 master_doc = 'index'
 source_suffix = ['.rst', '.md']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,15 +57,17 @@ Run this command in your terminal:
   jvn/cli
 
 .. toctree::
+  :caption: Callbacks
+  :hidden:
+
+  callbacks/fastai
+  callbacks/keras
+  
+.. toctree::
   :caption: Jupyter Notebook Extension
   :hidden:
 
   nbext/commit
   nbext/disable
 
-.. toctree::
-  :caption: Callbacks
-  :hidden:
 
-  callbacks/fastai
-  callbacks/keras

--- a/docs/jvn/cli.md
+++ b/docs/jvn/cli.md
@@ -1,1 +1,10 @@
-# Command Line
+## Command Line
+
+jovian init
+jovian clone
+jovian pull
+jovian version
+jovian install
+jovian activate
+jovian enable-ext
+jovian disable-ext

--- a/docs/jvn/cli.md
+++ b/docs/jvn/cli.md
@@ -1,10 +1,72 @@
-## Command Line
+## Command Line Commands
 
-jovian init
-jovian clone
-jovian pull
-jovian version
-jovian install
-jovian activate
-jovian enable-ext
-jovian disable-ext
+#### Initialize
+
+Requests for a API Key for a new user, can find the key at [Jovian](https://jnv.io). By clicking on `API key` button, key will be copied to the clipboard.
+
+```
+$ jovian init
+```
+
+#### Clone a Notebook
+
+Clone a notebook form Jovian, by clicking on the `Clone` button of a notebook repo the whole clone command will be copied to the clipboard.
+
+```
+$ jovian clone {notebook_id}
+```
+
+#### Pull the latest Notebook
+
+Pull the latest version of the notebook, use the command in a cloned repository or from a repository where you have committed to jovian.
+
+```
+$ jovian pull
+```
+
+```eval_rst
+.. caution::
+    Make sure the changes are committed if needed, pull overwrites the current notebook.
+```
+
+#### Install the required dependencies
+
+Install all the dependencies required to the the cloned notebook, use the command in a cloned repository.
+
+```
+$ jovian install
+```
+
+```eval_rst
+.. important:: The above command prompts
+    `
+    Please provide a name for the conda environment [{env_name}]:
+    `
+
+    Press enter to install the dependencies to `env_name` (base env if the content of the square brackets is empty) else provide the env name in the prompt.
+```
+
+#### Version
+
+Displays the current installed version of jovian library.
+
+```
+$ jovian version
+```
+
+#### Enable or Disable Jupyter Notebook Extension
+
+By default, the jovian jupyter extension is enabled.
+
+```
+$ jovian enable-ext
+```
+
+```
+$ jovian disable-ext
+```
+
+```eval_rst
+.. note::
+    The changes are observed when the webpage of the notebook is refreshed.
+```

--- a/docs/jvn/commit.md
+++ b/docs/jvn/commit.md
@@ -2,8 +2,4 @@
 
 ```eval_rst
 .. autofunction:: jovian.commit
-
-.. attention::
-    Pass notebook's name to nb_filename in certain environments like Jupyter Lab, password protected notebooks as sometimes it may fail to detect automatically.
-..
 ```

--- a/jovian/__init__.py
+++ b/jovian/__init__.py
@@ -55,6 +55,9 @@ def commit(secret=False, nb_filename=None, files=[], capture_env=True,
 
         artifacts (array, optional): Any outputs files or artifacts generated from the modeling processing.
             This can include model weights/checkpoints, generated CSVs, images etc.
+    
+    .. attention::
+        Pass notebook's name to nb_filename in ceratin environments like Jupyter Lab, password protected notebooks as sometimes it may fail to detect automatically in these environments.
 
     """
     global _current_slug
@@ -184,6 +187,14 @@ def log_hyperparams(data, verbose=True):
         data (dict): A python dict or a array of dicts to be recorded as hyperparmeters.
 
         verbose (bool, optional): By default it prints the acknowledgement, you can remove this by setting the argument to False. 
+
+    Example::
+
+        hyperparmas = {
+            arch_name   : "cnn_1"
+            lr          : .001
+        }
+        jovian.log_hyperparams(hyperparams)
     """
     global _data_blocks
     res = post_block(data, 'hyperparams')
@@ -198,7 +209,17 @@ def log_metrics(data, verbose=True):
     Args:
         data (dict): A python dict or a array of dicts to be recorded as metrics.
 
-        verbose (bool, optional): By default it prints the acknowledgement, you can remove this by setting the argument to False. .
+        verbose (bool, optional): By default it prints the acknowledgement, you can remove this by setting the argument to False.
+    
+    Example::
+
+        metrics = {
+            epoch       : 1
+            train_loss  : .5
+            val_loss    : .3
+            acc         : .94
+        }
+        jovian.log_metrics(metrics) 
     """
     global _data_blocks
     res = post_block(data, 'metrics')

--- a/jovian/callbacks/fastai_callback.py
+++ b/jovian/callbacks/fastai_callback.py
@@ -8,18 +8,19 @@ from jovian.utils.logger import log
 
 class FastaiCallback(Callback):
     """Fastai callback to automatically log hyperparameters and metrics.
- 
+
     Args:
         learn (Learner): A learner object reference of your current model.
 
         arch_name (string): A name for the model you're training. 
-    
-    .. code-block::
 
-        from jovian.callbacks.fastai_callback import FastaiCallback
+    Example
+        .. code-block::
 
-        jvn_cb = FastaiCallback(learn, 'res18')
-        learn.fit_one_cycle(5, callbacks = jvn_cb)
+            from jovian.callbacks.fastai_callback import FastaiCallback
+
+            jvn_cb = FastaiCallback(learn, 'res18')
+            learn.fit_one_cycle(5, callbacks = jvn_cb)
 
     .. admonition:: Tutorial
 

--- a/jovian/callbacks/fastai_callback.py
+++ b/jovian/callbacks/fastai_callback.py
@@ -7,12 +7,25 @@ from jovian.utils.logger import log
 
 
 class FastaiCallback(Callback):
-    """FastAI callback to log hyperparameters and metrics during model training.
-
+    """Fastai callback to automatically log hyperparameters and metrics.
+ 
     Args:
-        learn (Learner): A learner object with which you're fitting your model
+        learn (Learner): A learner object reference of your current model.
 
-        arch_name (string): A name for the architecture that you're using 
+        arch_name (string): A name for the model you're training. 
+    
+    .. code-block::
+
+        from jovian.callbacks.fastai_callback import FastaiCallback
+
+        jvn_cb = FastaiCallback(learn, 'res18')
+        learn.fit_one_cycle(5, callbacks = jvn_cb)
+
+    .. admonition:: Tutorial
+
+        Visit `this`_ for a detailed example on using the keras callback, also visit the *Records* tab
+        to see all the logs of that notebook logged by the callback.
+    .. _this: https://jvn.io/PrajwalPrashanth/7f16274fc3224d829941bc2553ef6061
     """
 
     def __init__(self, learn: Learner, arch_name: str):

--- a/jovian/callbacks/keras_callback.py
+++ b/jovian/callbacks/keras_callback.py
@@ -9,20 +9,21 @@ class KerasCallback(Callback):
 
     Args:
         arch_name (string):  A name for the model you’re training.
-    
-    .. code-block::
 
-        from jovian.callbacks.keras_callback import KerasCallback
+    Example
+        .. code-block::
 
-        jvn_cb = KerasCallback('resnet18')
-        model.fit(x_train, y_train, ...., callbacks=[jvn_cb])
-    
+            from jovian.callbacks.keras_callback import KerasCallback
+
+            jvn_cb = KerasCallback('resnet18')
+            model.fit(x_train, y_train, ...., callbacks=[jvn_cb])
+
     .. admonition:: Tutorial
 
         Visit `this`_ for a detailed example on using the fastai callback, also visit the *Records* tab
         to see all the logs of that notebook logged by the callback.
     .. _this: https://jvn.io/PrajwalPrashanth/34fd4e72905e460db2d16aafab285537
-        
+
     """
 
     def __init__(self, arch_name: str):

--- a/jovian/callbacks/keras_callback.py
+++ b/jovian/callbacks/keras_callback.py
@@ -8,10 +8,24 @@ class KerasCallback(Callback):
     """Keras Callback to log hyperparameters and metrics during model training.
 
     Args:
-        arch_name :  A name for the architecture that you're using
+        arch_name (string):  A name for the model you’re training.
+    
+    .. code-block::
+
+        from jovian.callbacks.keras_callback import KerasCallback
+
+        jvn_cb = KerasCallback('resnet18')
+        model.fit(x_train, y_train, ...., callbacks=[jvn_cb])
+    
+    .. admonition:: Tutorial
+
+        Visit `this`_ for a detailed example on using the fastai callback, also visit the *Records* tab
+        to see all the logs of that notebook logged by the callback.
+    .. _this: https://jvn.io/PrajwalPrashanth/34fd4e72905e460db2d16aafab285537
+        
     """
 
-    def __init__(self, arch_name):
+    def __init__(self, arch_name: str):
         self.arch_name = arch_name
 
     def on_train_begin(self, logs=None):

--- a/jovian/cli.py
+++ b/jovian/cli.py
@@ -51,9 +51,9 @@ def main():
         install(env_name=args.name)
     elif command == 'activate':
         activate()
-    elif command == 'enable_ext':
+    elif command == 'enable-ext':
         nb_ext()
-    elif command == 'disable_ext':
+    elif command == 'disable-ext':
         nb_ext(enable=False)
 
 

--- a/jovian/utils/credentials.py
+++ b/jovian/utils/credentials.py
@@ -94,7 +94,7 @@ def write_api_key(key):
 def request_api_key():
     """Ask the user to provide the API key"""
     log("Please enter your API key (from " + WEBAPP_URL + " ):")
-    api_key = getpass()
+    api_key = getpass(prompt="API Key:")
     return api_key
 
 


### PR DESCRIPTION
Tasks Done:
* Document CLI commands
* Document keras and fastai callbacks
* Import the docstring of callbacks to docs site
* Move callbacks above extension in the side nav bar
* Change cli commands enable_ext to enable-ext and disable_ext to disable-ext
* Change the prompt message, when jovian init from Password: to API Key:
* Add attention, tutorials, examples in the docstrings wherever needed

Preview at https://prajwalprashanth-demo.readthedocs.io/en/pp-ch194-doc-cli-callbacks-add-examples/jvn/cli.html